### PR TITLE
Add destructive button style for the action sheet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,5 @@ fastlane/test_output
 # https://github.com/johnno1962/injectionforxcode
 
 iOSInjectionProject/
+
+*.DS_Store

--- a/SwiftUI Kit/Groupings/ButtonsGroup.swift
+++ b/SwiftUI Kit/Groupings/ButtonsGroup.swift
@@ -13,6 +13,7 @@ struct ButtonsGroup: View {
     @State private var showingActionSheet = false
     
     var body: some View {
+<<<<<<< Updated upstream
         Group {
             SectionView(
                 title: "Button",
@@ -47,6 +48,42 @@ struct ButtonsGroup: View {
                                 .cancel()
                             ])
                         }
+=======
+        SectionView(
+            title: "Button",
+            description: "A control that performs an action when triggered.",
+            content: {
+                Group {
+                    Button(action: {
+                        self.showingAlert = true
+                    }) {
+                        Text("Show Alert")
+                    }
+                    .alert(isPresented: $showingAlert) {
+                        Alert(title: Text("Title"), message: Text("Message"), dismissButton: .default(Text("Done")))
+                    }
+                    
+                    Button(action: {
+                        self.showingSheet = true
+                    }) {
+                        Text("Show Sheet")
+                    }.sheet(isPresented: $showingSheet) {
+                        Text("Sheet")
+                    }
+                    
+                    Button(action: {
+                        self.showingActionSheet = true
+                    }) {
+                        Text("Show Action Sheet")
+                    }
+                    .actionSheet(isPresented: $showingActionSheet) {
+                        ActionSheet(title: Text("Title"), message: Text("Message"), buttons: [
+                            .destructive(Text("Delete")),
+                            .default(Text("Option 1")) { },
+                            .default(Text("Option 2")) { },
+                            .cancel()
+                        ])
+>>>>>>> Stashed changes
                     }
                 }
             )

--- a/SwiftUI Kit/Groupings/ButtonsGroup.swift
+++ b/SwiftUI Kit/Groupings/ButtonsGroup.swift
@@ -4,7 +4,6 @@
 //
 //  Created by Jordan Singer on 7/10/20.
 //
-
 import SwiftUI
 
 struct ButtonsGroup: View {
@@ -13,7 +12,6 @@ struct ButtonsGroup: View {
     @State private var showingActionSheet = false
     
     var body: some View {
-<<<<<<< Updated upstream
         Group {
             SectionView(
                 title: "Button",
@@ -44,46 +42,12 @@ struct ButtonsGroup: View {
                         }
                         .actionSheet(isPresented: $showingActionSheet) {
                             ActionSheet(title: Text("Title"), message: Text("Message"), buttons: [
-                                .default(Text("OK")) { },
+                                .destructive(Text("Delete")),
+                                .default(Text("Option 1")) { },
+                                .default((Text("Option 2"))) { },
                                 .cancel()
                             ])
                         }
-=======
-        SectionView(
-            title: "Button",
-            description: "A control that performs an action when triggered.",
-            content: {
-                Group {
-                    Button(action: {
-                        self.showingAlert = true
-                    }) {
-                        Text("Show Alert")
-                    }
-                    .alert(isPresented: $showingAlert) {
-                        Alert(title: Text("Title"), message: Text("Message"), dismissButton: .default(Text("Done")))
-                    }
-                    
-                    Button(action: {
-                        self.showingSheet = true
-                    }) {
-                        Text("Show Sheet")
-                    }.sheet(isPresented: $showingSheet) {
-                        Text("Sheet")
-                    }
-                    
-                    Button(action: {
-                        self.showingActionSheet = true
-                    }) {
-                        Text("Show Action Sheet")
-                    }
-                    .actionSheet(isPresented: $showingActionSheet) {
-                        ActionSheet(title: Text("Title"), message: Text("Message"), buttons: [
-                            .destructive(Text("Delete")),
-                            .default(Text("Option 1")) { },
-                            .default(Text("Option 2")) { },
-                            .cancel()
-                        ])
->>>>>>> Stashed changes
                     }
                 }
             )


### PR DESCRIPTION
- Add the `.destructive` button style for the action sheet component
- Add a second default button to further emphasize that the action sheet is meant to be used to present explicit options for the user to choose from (instead of the "OK"/"Done" dismissal which is usually better suited for an alert)
- Add `*.DS_Store` to gitignore cuz it’s annoying

Per the HIG, the destructive style is the first option presented ([reference](https://developer.apple.com/design/human-interface-guidelines/ios/views/action-sheets/)).