### PR TITLE
Resize previews to .sizeThatFits

### DIFF
--- a/SwiftUI Kit/GroupView.swift
+++ b/SwiftUI Kit/GroupView.swift
@@ -23,5 +23,6 @@ struct GroupView<Content: View>: View {
 struct GroupView_Previews: PreviewProvider {
     static var previews: some View {
         GroupView(title: "Group", content: { Text("Content") })
+            .previewLayout(.sizeThatFits)
     }
 }

--- a/SwiftUI Kit/Groupings/ButtonsGroup.swift
+++ b/SwiftUI Kit/Groupings/ButtonsGroup.swift
@@ -91,5 +91,6 @@ struct ButtonsGroup: View {
 struct ButtonsGroup_Previews: PreviewProvider {
     static var previews: some View {
         ButtonsGroup()
+            .previewLayout(.sizeThatFits)
     }
 }

--- a/SwiftUI Kit/Groupings/ColorsGroup.swift
+++ b/SwiftUI Kit/Groupings/ColorsGroup.swift
@@ -61,5 +61,6 @@ struct Swatch: View {
 struct ColorsGroup_Previews: PreviewProvider {
     static var previews: some View {
         ColorsGroup()
+            .previewLayout(.sizeThatFits)
     }
 }

--- a/SwiftUI Kit/Groupings/ControlsGroup.swift
+++ b/SwiftUI Kit/Groupings/ControlsGroup.swift
@@ -82,5 +82,6 @@ enum Flavor: String, CaseIterable, Identifiable {
 struct ControlsGroup_Previews: PreviewProvider {
     static var previews: some View {
         ControlsGroup()
+            .previewLayout(.sizeThatFits)
     }
 }

--- a/SwiftUI Kit/Groupings/FontsGroup.swift
+++ b/SwiftUI Kit/Groupings/FontsGroup.swift
@@ -77,5 +77,6 @@ struct FontsGroup: View {
 struct FontsGroup_Previews: PreviewProvider {
     static var previews: some View {
         FontsGroup()
+            .previewLayout(.sizeThatFits)
     }
 }

--- a/SwiftUI Kit/Groupings/HapticsGroup.swift
+++ b/SwiftUI Kit/Groupings/HapticsGroup.swift
@@ -74,5 +74,6 @@ struct HapticsGroup: View {
 struct HapticsGroup_Previews: PreviewProvider {
     static var previews: some View {
         HapticsGroup()
+            .previewLayout(.sizeThatFits)
     }
 }

--- a/SwiftUI Kit/Groupings/ImagesGroup.swift
+++ b/SwiftUI Kit/Groupings/ImagesGroup.swift
@@ -39,5 +39,6 @@ struct ImagesGroup: View {
 struct ImagesGroup_Previews: PreviewProvider {
     static var previews: some View {
         ImagesGroup()
+            .previewLayout(.sizeThatFits)
     }
 }

--- a/SwiftUI Kit/Groupings/IndicatorsGroup.swift
+++ b/SwiftUI Kit/Groupings/IndicatorsGroup.swift
@@ -29,5 +29,6 @@ struct IndicatorsGroup: View {
 struct IndicatorsGroup_Previews: PreviewProvider {
     static var previews: some View {
         IndicatorsGroup()
+            .previewLayout(.sizeThatFits)
     }
 }

--- a/SwiftUI Kit/Groupings/ShapesGroup.swift
+++ b/SwiftUI Kit/Groupings/ShapesGroup.swift
@@ -56,5 +56,6 @@ struct ShapesGroup: View {
 struct ShapesGroup_Previews: PreviewProvider {
     static var previews: some View {
         ShapesGroup()
+            .previewLayout(.sizeThatFits)
     }
 }

--- a/SwiftUI Kit/Groupings/TextGroup.swift
+++ b/SwiftUI Kit/Groupings/TextGroup.swift
@@ -53,5 +53,6 @@ struct TextGroup: View {
 struct TextGroup_Previews: PreviewProvider {
     static var previews: some View {
         TextGroup()
+            .previewLayout(.sizeThatFits)
     }
 }

--- a/SwiftUI Kit/SectionView.swift
+++ b/SwiftUI Kit/SectionView.swift
@@ -25,5 +25,6 @@ struct SectionView<Content: View>: View {
 struct SectionView_Previews: PreviewProvider {
     static var previews: some View {
         SectionView(title: "Section", description: "Description", content: { Text("Content") })
+            .previewLayout(.sizeThatFits)
     }
 }


### PR DESCRIPTION
Fixes #2 

There’s still some quirks with how a few of the previews render (like the Sign in with Apple button) but maybe for another PR :) 