### PR TITLE
Add watchOS app + other improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SwiftUI Kit
-A SwiftUI system components and interactions demo app based on iOS 14 and macOS Big Sur
+A SwiftUI system components and interactions demo app based on iOS 14, macOS Big Sur, and watchOS 4.
 
 ![SwiftUI Kit](https://user-images.githubusercontent.com/110813/87210094-5accf380-c2e2-11ea-91c9-4f21aa313bc6.png)
 
@@ -19,9 +19,12 @@ To change the accent color and see how it affects the system components, go to t
 Please feel free to submit pull requests in order to contribute back to SwiftUI Kit. This is for the SwiftUI community!
 
 #### SwiftUI Resources
-[Recreate](https://recreatecode.com) - A video series about recreating popular UI with SwiftUI
+- [Recreate](https://recreatecode.com) - A video series about recreating popular UI with SwiftUI
+- [Primitive](https://primitive.school) - Learn SwiftUI for designers
 
-[Primitive](https://primitive.school) - Learn SwiftUI for designers
+#### Apple Resources
+- [Apple Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/) - Apple’s design guidelines for creating best-in-class apps.
+- [SF Symbols](https://developer.apple.com/sf-symbols/) – Apple’s comprehensive library of vector-based symbols included in Apple’s system fonts that you can incorporate into your app.
 
 By [Jordan Singer](https://ibuildmyideas.com) ([@jsngr](https://twitter.com/jsngr))
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SwiftUI Kit
-A SwiftUI system components and interactions demo app based on iOS 14, macOS Big Sur, and watchOS 4.
+A SwiftUI system components and interactions demo app based on iOS 14, macOS Big Sur, and watchOS 7.
 
 ![SwiftUI Kit](https://user-images.githubusercontent.com/110813/87210094-5accf380-c2e2-11ea-91c9-4f21aa313bc6.png)
 

--- a/SwiftUI Kit watchOS Extension/Assets.xcassets/Complication.complicationset/Circular.imageset/Contents.json
+++ b/SwiftUI Kit watchOS Extension/Assets.xcassets/Complication.complicationset/Circular.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwiftUI Kit watchOS Extension/Assets.xcassets/Complication.complicationset/Contents.json
+++ b/SwiftUI Kit watchOS Extension/Assets.xcassets/Complication.complicationset/Contents.json
@@ -1,0 +1,53 @@
+{
+  "assets" : [
+    {
+      "filename" : "Circular.imageset",
+      "idiom" : "watch",
+      "role" : "circular"
+    },
+    {
+      "filename" : "Extra Large.imageset",
+      "idiom" : "watch",
+      "role" : "extra-large"
+    },
+    {
+      "filename" : "Graphic Bezel.imageset",
+      "idiom" : "watch",
+      "role" : "graphic-bezel"
+    },
+    {
+      "filename" : "Graphic Circular.imageset",
+      "idiom" : "watch",
+      "role" : "graphic-circular"
+    },
+    {
+      "filename" : "Graphic Corner.imageset",
+      "idiom" : "watch",
+      "role" : "graphic-corner"
+    },
+    {
+      "filename" : "Graphic Extra Large.imageset",
+      "idiom" : "watch",
+      "role" : "graphic-extra-large"
+    },
+    {
+      "filename" : "Graphic Large Rectangular.imageset",
+      "idiom" : "watch",
+      "role" : "graphic-large-rectangular"
+    },
+    {
+      "filename" : "Modular.imageset",
+      "idiom" : "watch",
+      "role" : "modular"
+    },
+    {
+      "filename" : "Utilitarian.imageset",
+      "idiom" : "watch",
+      "role" : "utilitarian"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwiftUI Kit watchOS Extension/Assets.xcassets/Complication.complicationset/Extra Large.imageset/Contents.json
+++ b/SwiftUI Kit watchOS Extension/Assets.xcassets/Complication.complicationset/Extra Large.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwiftUI Kit watchOS Extension/Assets.xcassets/Complication.complicationset/Graphic Bezel.imageset/Contents.json
+++ b/SwiftUI Kit watchOS Extension/Assets.xcassets/Complication.complicationset/Graphic Bezel.imageset/Contents.json
@@ -1,0 +1,18 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwiftUI Kit watchOS Extension/Assets.xcassets/Complication.complicationset/Graphic Circular.imageset/Contents.json
+++ b/SwiftUI Kit watchOS Extension/Assets.xcassets/Complication.complicationset/Graphic Circular.imageset/Contents.json
@@ -1,0 +1,18 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwiftUI Kit watchOS Extension/Assets.xcassets/Complication.complicationset/Graphic Corner.imageset/Contents.json
+++ b/SwiftUI Kit watchOS Extension/Assets.xcassets/Complication.complicationset/Graphic Corner.imageset/Contents.json
@@ -1,0 +1,18 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwiftUI Kit watchOS Extension/Assets.xcassets/Complication.complicationset/Graphic Extra Large.imageset/Contents.json
+++ b/SwiftUI Kit watchOS Extension/Assets.xcassets/Complication.complicationset/Graphic Extra Large.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwiftUI Kit watchOS Extension/Assets.xcassets/Complication.complicationset/Graphic Large Rectangular.imageset/Contents.json
+++ b/SwiftUI Kit watchOS Extension/Assets.xcassets/Complication.complicationset/Graphic Large Rectangular.imageset/Contents.json
@@ -1,0 +1,18 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwiftUI Kit watchOS Extension/Assets.xcassets/Complication.complicationset/Modular.imageset/Contents.json
+++ b/SwiftUI Kit watchOS Extension/Assets.xcassets/Complication.complicationset/Modular.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwiftUI Kit watchOS Extension/Assets.xcassets/Complication.complicationset/Utilitarian.imageset/Contents.json
+++ b/SwiftUI Kit watchOS Extension/Assets.xcassets/Complication.complicationset/Utilitarian.imageset/Contents.json
@@ -1,0 +1,28 @@
+{
+  "images" : [
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : "<=145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">161"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">145"
+    },
+    {
+      "idiom" : "watch",
+      "scale" : "2x",
+      "screen-width" : ">183"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwiftUI Kit watchOS Extension/Assets.xcassets/Contents.json
+++ b/SwiftUI Kit watchOS Extension/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwiftUI Kit watchOS Extension/ComplicationController.swift
+++ b/SwiftUI Kit watchOS Extension/ComplicationController.swift
@@ -1,0 +1,59 @@
+//
+//  ComplicationController.swift
+//  SwiftUI Kit watchOS Extension
+//
+//  Created by Ramy Majouji on 7/11/20.
+//
+
+import ClockKit
+
+
+class ComplicationController: NSObject, CLKComplicationDataSource {
+    
+    // MARK: - Complication Configuration
+
+    func getComplicationDescriptors(handler: @escaping ([CLKComplicationDescriptor]) -> Void) {
+        let descriptors = [
+            CLKComplicationDescriptor(identifier: "complication", displayName: "SwiftUI Kit", supportedFamilies: CLKComplicationFamily.allCases)
+            // Multiple complication support can be added here with more descriptors
+        ]
+        
+        // Call the handler with the currently supported complication descriptors
+        handler(descriptors)
+    }
+    
+    func handleSharedComplicationDescriptors(_ complicationDescriptors: [CLKComplicationDescriptor]) {
+        // Do any necessary work to support these newly shared complication descriptors
+    }
+
+    // MARK: - Timeline Configuration
+    
+    func getTimelineEndDate(for complication: CLKComplication, withHandler handler: @escaping (Date?) -> Void) {
+        // Call the handler with the last entry date you can currently provide or nil if you can't support future timelines
+        handler(nil)
+    }
+    
+    func getPrivacyBehavior(for complication: CLKComplication, withHandler handler: @escaping (CLKComplicationPrivacyBehavior) -> Void) {
+        // Call the handler with your desired behavior when the device is locked
+        handler(.showOnLockScreen)
+    }
+
+    // MARK: - Timeline Population
+    
+    func getCurrentTimelineEntry(for complication: CLKComplication, withHandler handler: @escaping (CLKComplicationTimelineEntry?) -> Void) {
+        // Call the handler with the current timeline entry
+        handler(nil)
+    }
+    
+    func getTimelineEntries(for complication: CLKComplication, after date: Date, limit: Int, withHandler handler: @escaping ([CLKComplicationTimelineEntry]?) -> Void) {
+        // Call the handler with the timeline entries after the given date
+        handler(nil)
+    }
+
+    // MARK: - Sample Templates
+    
+    func getLocalizableSampleTemplate(for complication: CLKComplication, withHandler handler: @escaping (CLKComplicationTemplate?) -> Void) {
+        // This method will be called once per supported complication, and the results will be cached
+        handler(nil)
+    }
+}

--- a/SwiftUI Kit watchOS Extension/Info.plist
+++ b/SwiftUI Kit watchOS Extension/Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>SwiftUI Kit watchOS Extension</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>CLKComplicationPrincipalClass</key>
+	<string>$(PRODUCT_MODULE_NAME).ComplicationController</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>WKAppBundleIdentifier</key>
+			<string>example.SwiftUI-Kit.watchkitapp</string>
+		</dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.watchkit</string>
+	</dict>
+</dict>
+</plist>

--- a/SwiftUI Kit watchOS Extension/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/SwiftUI Kit watchOS Extension/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwiftUI Kit watchOS/Info.plist
+++ b/SwiftUI Kit watchOS/Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>SwiftUI Kit iOS</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+	</array>
+	<key>WKCompanionAppBundleIdentifier</key>
+	<string>example.SwiftUI-Kit</string>
+	<key>WKWatchKitApp</key>
+	<true/>
+</dict>
+</plist>

--- a/SwiftUI Kit.xcodeproj/project.pbxproj
+++ b/SwiftUI Kit.xcodeproj/project.pbxproj
@@ -7,6 +7,23 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2D8F82FD24BA011800E90F0B /* SwiftUI Kit watchOS Extension.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 2D8F82FC24BA011800E90F0B /* SwiftUI Kit watchOS Extension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		2D8F830624BA011800E90F0B /* ComplicationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D8F830524BA011800E90F0B /* ComplicationController.swift */; };
+		2D8F830824BA011800E90F0B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2D8F830724BA011800E90F0B /* Assets.xcassets */; };
+		2D8F830B24BA011900E90F0B /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2D8F830A24BA011900E90F0B /* Preview Assets.xcassets */; };
+		2D8F830F24BA011900E90F0B /* SwiftUI Kit watchOS.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 2D8F82F324BA011700E90F0B /* SwiftUI Kit watchOS.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		2D8F831824BA013E00E90F0B /* GroupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 861EC65524B90E16005C2F44 /* GroupView.swift */; };
+		2D8F831924BA013E00E90F0B /* ShapesGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 861EC66024B912C9005C2F44 /* ShapesGroup.swift */; };
+		2D8F831A24BA013E00E90F0B /* IndicatorsGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 861EC66824B91D4E005C2F44 /* IndicatorsGroup.swift */; };
+		2D8F831B24BA013E00E90F0B /* ImagesGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 861EC66A24B91E1D005C2F44 /* ImagesGroup.swift */; };
+		2D8F831D24BA013E00E90F0B /* TextGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 861EC65A24B91065005C2F44 /* TextGroup.swift */; };
+		2D8F831E24BA013E00E90F0B /* SectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 861EC66424B914FB005C2F44 /* SectionView.swift */; };
+		2D8F831F24BA013E00E90F0B /* ColorsGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 861EC66224B912D2005C2F44 /* ColorsGroup.swift */; };
+		2D8F832024BA013E00E90F0B /* ControlsGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 861EC65C24B9106E005C2F44 /* ControlsGroup.swift */; };
+		2D8F832124BA013E00E90F0B /* FontsGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 861EC65E24B91075005C2F44 /* FontsGroup.swift */; };
+		2D8F832224BA013E00E90F0B /* ButtonsGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 861EC66624B91AE8005C2F44 /* ButtonsGroup.swift */; };
+		2DC7DE5624BA0D9A00A84252 /* SwiftUI_KitApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 861EC64524B90DD9005C2F44 /* SwiftUI_KitApp.swift */; };
+		2DC7DE5724BA0D9A00A84252 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 861EC64724B90DD9005C2F44 /* ContentView.swift */; };
 		861EC64624B90DD9005C2F44 /* SwiftUI_KitApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 861EC64524B90DD9005C2F44 /* SwiftUI_KitApp.swift */; };
 		861EC64824B90DD9005C2F44 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 861EC64724B90DD9005C2F44 /* ContentView.swift */; };
 		861EC64A24B90DDB005C2F44 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 861EC64924B90DDB005C2F44 /* Assets.xcassets */; };
@@ -37,7 +54,56 @@
 		F95A4E2C24B9938500697538 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 861EC64924B90DDB005C2F44 /* Assets.xcassets */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		2D8F82FE24BA011800E90F0B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 861EC63A24B90DD9005C2F44 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2D8F82FB24BA011800E90F0B;
+			remoteInfo = "SwiftUI Kit watchOS Extension";
+		};
+		2D8F830D24BA011900E90F0B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 861EC63A24B90DD9005C2F44 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2D8F82F224BA011700E90F0B;
+			remoteInfo = "SwiftUI Kit watchOS";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		2D8F831024BA011900E90F0B /* Embed Watch Content */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "$(CONTENTS_FOLDER_PATH)/Watch";
+			dstSubfolderSpec = 16;
+			files = (
+				2D8F830F24BA011900E90F0B /* SwiftUI Kit watchOS.app in Embed Watch Content */,
+			);
+			name = "Embed Watch Content";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2D8F831324BA011900E90F0B /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				2D8F82FD24BA011800E90F0B /* SwiftUI Kit watchOS Extension.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
+		2D8F82F324BA011700E90F0B /* SwiftUI Kit watchOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SwiftUI Kit watchOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		2D8F82F724BA011800E90F0B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		2D8F82FC24BA011800E90F0B /* SwiftUI Kit watchOS Extension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = "SwiftUI Kit watchOS Extension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		2D8F830524BA011800E90F0B /* ComplicationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplicationController.swift; sourceTree = "<group>"; };
+		2D8F830724BA011800E90F0B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		2D8F830A24BA011900E90F0B /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		2D8F830C24BA011900E90F0B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		861EC64224B90DD9005C2F44 /* SwiftUI Kit iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "SwiftUI Kit iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		861EC64524B90DD9005C2F44 /* SwiftUI_KitApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUI_KitApp.swift; sourceTree = "<group>"; };
 		861EC64724B90DD9005C2F44 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -61,6 +127,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		2D8F82F924BA011800E90F0B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		861EC63F24B90DD9005C2F44 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -78,12 +151,41 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2D8F82F424BA011700E90F0B /* SwiftUI Kit watchOS */ = {
+			isa = PBXGroup;
+			children = (
+				2D8F82F724BA011800E90F0B /* Info.plist */,
+			);
+			path = "SwiftUI Kit watchOS";
+			sourceTree = "<group>";
+		};
+		2D8F830024BA011800E90F0B /* SwiftUI Kit watchOS Extension */ = {
+			isa = PBXGroup;
+			children = (
+				2D8F830524BA011800E90F0B /* ComplicationController.swift */,
+				2D8F830724BA011800E90F0B /* Assets.xcassets */,
+				2D8F830C24BA011900E90F0B /* Info.plist */,
+				2D8F830924BA011900E90F0B /* Preview Content */,
+			);
+			path = "SwiftUI Kit watchOS Extension";
+			sourceTree = "<group>";
+		};
+		2D8F830924BA011900E90F0B /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				2D8F830A24BA011900E90F0B /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
 		861EC63924B90DD9005C2F44 = {
 			isa = PBXGroup;
 			children = (
 				F9E3381324B9A1DC00D233B7 /* SwiftUI Kit iOS */,
 				861EC64424B90DD9005C2F44 /* SwiftUI Kit */,
 				F95A4E1024B9932000697538 /* SwiftUI Kit Mac */,
+				2D8F82F424BA011700E90F0B /* SwiftUI Kit watchOS */,
+				2D8F830024BA011800E90F0B /* SwiftUI Kit watchOS Extension */,
 				861EC64324B90DD9005C2F44 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -93,6 +195,8 @@
 			children = (
 				861EC64224B90DD9005C2F44 /* SwiftUI Kit iOS.app */,
 				F95A4E0F24B9932000697538 /* SwiftUI Kit Mac.app */,
+				2D8F82F324BA011700E90F0B /* SwiftUI Kit watchOS.app */,
+				2D8F82FC24BA011800E90F0B /* SwiftUI Kit watchOS Extension.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -155,6 +259,40 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		2D8F82F224BA011700E90F0B /* SwiftUI Kit watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2D8F831724BA011900E90F0B /* Build configuration list for PBXNativeTarget "SwiftUI Kit watchOS" */;
+			buildPhases = (
+				2D8F82F124BA011700E90F0B /* Resources */,
+				2D8F831324BA011900E90F0B /* Embed App Extensions */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				2D8F82FF24BA011800E90F0B /* PBXTargetDependency */,
+			);
+			name = "SwiftUI Kit watchOS";
+			productName = "SwiftUI Kit watchOS";
+			productReference = 2D8F82F324BA011700E90F0B /* SwiftUI Kit watchOS.app */;
+			productType = "com.apple.product-type.application.watchapp2";
+		};
+		2D8F82FB24BA011800E90F0B /* SwiftUI Kit watchOS Extension */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 2D8F831624BA011900E90F0B /* Build configuration list for PBXNativeTarget "SwiftUI Kit watchOS Extension" */;
+			buildPhases = (
+				2D8F82F824BA011800E90F0B /* Sources */,
+				2D8F82F924BA011800E90F0B /* Frameworks */,
+				2D8F82FA24BA011800E90F0B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "SwiftUI Kit watchOS Extension";
+			productName = "SwiftUI Kit watchOS Extension";
+			productReference = 2D8F82FC24BA011800E90F0B /* SwiftUI Kit watchOS Extension.appex */;
+			productType = "com.apple.product-type.watchkit2-extension";
+		};
 		861EC64124B90DD9005C2F44 /* SwiftUI Kit iOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 861EC65124B90DDB005C2F44 /* Build configuration list for PBXNativeTarget "SwiftUI Kit iOS" */;
@@ -162,10 +300,12 @@
 				861EC63E24B90DD9005C2F44 /* Sources */,
 				861EC63F24B90DD9005C2F44 /* Frameworks */,
 				861EC64024B90DD9005C2F44 /* Resources */,
+				2D8F831024BA011900E90F0B /* Embed Watch Content */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				2D8F830E24BA011900E90F0B /* PBXTargetDependency */,
 			);
 			name = "SwiftUI Kit iOS";
 			productName = "SwiftUI Kit";
@@ -198,6 +338,12 @@
 				LastSwiftUpdateCheck = 1200;
 				LastUpgradeCheck = 1200;
 				TargetAttributes = {
+					2D8F82F224BA011700E90F0B = {
+						CreatedOnToolsVersion = 12.0;
+					};
+					2D8F82FB24BA011800E90F0B = {
+						CreatedOnToolsVersion = 12.0;
+					};
 					861EC64124B90DD9005C2F44 = {
 						CreatedOnToolsVersion = 12.0;
 					};
@@ -221,11 +367,29 @@
 			targets = (
 				861EC64124B90DD9005C2F44 /* SwiftUI Kit iOS */,
 				F95A4E0E24B9932000697538 /* SwiftUI Kit Mac */,
+				2D8F82F224BA011700E90F0B /* SwiftUI Kit watchOS */,
+				2D8F82FB24BA011800E90F0B /* SwiftUI Kit watchOS Extension */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		2D8F82F124BA011700E90F0B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		2D8F82FA24BA011800E90F0B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2D8F830B24BA011900E90F0B /* Preview Assets.xcassets in Resources */,
+				2D8F830824BA011800E90F0B /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		861EC64024B90DD9005C2F44 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -246,6 +410,26 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		2D8F82F824BA011800E90F0B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2D8F832124BA013E00E90F0B /* FontsGroup.swift in Sources */,
+				2D8F831A24BA013E00E90F0B /* IndicatorsGroup.swift in Sources */,
+				2D8F831E24BA013E00E90F0B /* SectionView.swift in Sources */,
+				2DC7DE5624BA0D9A00A84252 /* SwiftUI_KitApp.swift in Sources */,
+				2D8F831F24BA013E00E90F0B /* ColorsGroup.swift in Sources */,
+				2D8F831B24BA013E00E90F0B /* ImagesGroup.swift in Sources */,
+				2D8F832224BA013E00E90F0B /* ButtonsGroup.swift in Sources */,
+				2D8F831824BA013E00E90F0B /* GroupView.swift in Sources */,
+				2D8F832024BA013E00E90F0B /* ControlsGroup.swift in Sources */,
+				2DC7DE5724BA0D9A00A84252 /* ContentView.swift in Sources */,
+				2D8F831D24BA013E00E90F0B /* TextGroup.swift in Sources */,
+				2D8F830624BA011800E90F0B /* ComplicationController.swift in Sources */,
+				2D8F831924BA013E00E90F0B /* ShapesGroup.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		861EC63E24B90DD9005C2F44 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -287,7 +471,104 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		2D8F82FF24BA011800E90F0B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2D8F82FB24BA011800E90F0B /* SwiftUI Kit watchOS Extension */;
+			targetProxy = 2D8F82FE24BA011800E90F0B /* PBXContainerItemProxy */;
+		};
+		2D8F830E24BA011900E90F0B /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2D8F82F224BA011700E90F0B /* SwiftUI Kit watchOS */;
+			targetProxy = 2D8F830D24BA011900E90F0B /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
 /* Begin XCBuildConfiguration section */
+		2D8F831124BA011900E90F0B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				IBSC_MODULE = SwiftUI_Kit_watchOS_Extension;
+				INFOPLIST_FILE = "SwiftUI Kit watchOS/Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "example.SwiftUI-Kit.watchkitapp";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 7.0;
+			};
+			name = Debug;
+		};
+		2D8F831224BA011900E90F0B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				IBSC_MODULE = SwiftUI_Kit_watchOS_Extension;
+				INFOPLIST_FILE = "SwiftUI Kit watchOS/Info.plist";
+				PRODUCT_BUNDLE_IDENTIFIER = "example.SwiftUI-Kit.watchkitapp";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 7.0;
+			};
+			name = Release;
+		};
+		2D8F831424BA011900E90F0B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"SwiftUI Kit watchOS Extension/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = "SwiftUI Kit watchOS Extension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "example.SwiftUI-Kit.watchkitapp.watchkitextension";
+				PRODUCT_NAME = "${TARGET_NAME}";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 7.0;
+			};
+			name = Debug;
+		};
+		2D8F831524BA011900E90F0B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_COMPLICATION_NAME = Complication;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_ASSET_PATHS = "\"SwiftUI Kit watchOS Extension/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				INFOPLIST_FILE = "SwiftUI Kit watchOS Extension/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = "example.SwiftUI-Kit.watchkitapp.watchkitextension";
+				PRODUCT_NAME = "${TARGET_NAME}";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 7.0;
+			};
+			name = Release;
+		};
 		861EC64F24B90DDB005C2F44 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -495,6 +776,24 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		2D8F831624BA011900E90F0B /* Build configuration list for PBXNativeTarget "SwiftUI Kit watchOS Extension" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2D8F831424BA011900E90F0B /* Debug */,
+				2D8F831524BA011900E90F0B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		2D8F831724BA011900E90F0B /* Build configuration list for PBXNativeTarget "SwiftUI Kit watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				2D8F831124BA011900E90F0B /* Debug */,
+				2D8F831224BA011900E90F0B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		861EC63D24B90DD9005C2F44 /* Build configuration list for PBXProject "SwiftUI Kit" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/SwiftUI Kit/Assets.xcassets/StrokeColor.colorset/Contents.json
+++ b/SwiftUI Kit/Assets.xcassets/StrokeColor.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.050",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.080",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/SwiftUI Kit/ContentView.swift
+++ b/SwiftUI Kit/ContentView.swift
@@ -27,10 +27,10 @@ struct ContentView: View {
 
     var body: some View {
         NavigationView {
-            #if os(iOS)
+            #if os(iOS) || os(watchOS)
             list.navigationBarTitle("SwiftUI")
             Text("Select a group")
-            #else
+            #elseif os(OSX)
             list.listStyle(SidebarListStyle())
             Text("Select a group").frame(maxWidth: .infinity, maxHeight: .infinity)
             #endif

--- a/SwiftUI Kit/Groupings/ButtonsGroup.swift
+++ b/SwiftUI Kit/Groupings/ButtonsGroup.swift
@@ -77,6 +77,7 @@ struct ButtonsGroup: View {
                 }
             )
             
+            #if os(iOS) || os(OSX)
             SectionView(
                 title: "SignInWithAppleButton",
                 description: "A control that you add to your interface to allow users to sign in with their Apple ID.",
@@ -92,6 +93,7 @@ struct ButtonsGroup: View {
                     )
                 }
             )
+            #endif
         }
     }
 }

--- a/SwiftUI Kit/Groupings/ColorsGroup.swift
+++ b/SwiftUI Kit/Groupings/ColorsGroup.swift
@@ -42,13 +42,6 @@ struct ColorsGroup: View {
 
 struct Swatch: View {
     var color: StandardColor
-
-    #if os(iOS)
-    var lineColor = Color(UIColor.label.withAlphaComponent(0.2))
-    #else
-    var lineColor = Color(NSColor.labelColor.withAlphaComponent(0.2))
-    #endif
-    
     var body: some View {
         HStack(spacing: 12) {
             RoundedRectangle(cornerRadius: 4)
@@ -56,7 +49,7 @@ struct Swatch: View {
                 .frame(width: 24, height: 24)
                 .overlay(
                     RoundedRectangle(cornerRadius: 4)
-                        .stroke(lineColor, lineWidth: 1)
+                        .stroke(Color("StrokeColor"), lineWidth: 1)
                 )
             Text(color.name)
             Spacer()

--- a/SwiftUI Kit/Groupings/ControlsGroup.swift
+++ b/SwiftUI Kit/Groupings/ControlsGroup.swift
@@ -28,33 +28,40 @@ struct ControlsGroup: View {
                         Text("Vanilla").tag(Flavor.vanilla)
                         Text("Strawberry").tag(Flavor.strawberry)
                     }
-
+                    #if os(iOS) || os(OSX)
                     Picker("Flavor", selection: $selectedFlavor) {
                         Text("Chocolate").tag(Flavor.chocolate)
                         Text("Vanilla").tag(Flavor.vanilla)
                         Text("Strawberry").tag(Flavor.strawberry)
                     }
                     .pickerStyle(SegmentedPickerStyle())
+                    #endif
                 }
             }
             
+            #if os(iOS) || os(OSX)
             SectionView(title: "DatePicker", description: "A control for selecting an absolute date.") {
                 DatePicker(selection: $birthday, in: ...Date(), displayedComponents: .date) {
                     Text("Birthday")
                 }
             }
+            #endif
             
             SectionView(title: "Slider", description: "A control for selecting a value from a bounded linear range of values.") {
                 Slider(value: $volume, in: 0...100)
             }
             
+            #if os(iOS) || os(OSX)
             SectionView(title: "Stepper", description: "A control used to perform semantic increment and decrement actions.") {
                 Stepper("Age: \(age)", value: $age, in: 0...100)
             }
+            #endif
             
+            #if os(iOS) || os(OSX)
             SectionView(title: "ColorPicker", description: "A control used to select a color from the system color picker UI.") {
                 ColorPicker("Color", selection: $color)
             }
+            #endif
         }
     }
 }

--- a/SwiftUI Kit/Groupings/ImagesGroup.swift
+++ b/SwiftUI Kit/Groupings/ImagesGroup.swift
@@ -17,7 +17,20 @@ struct ImagesGroup: View {
                     Image("Image")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
-                        .frame(height: 128)
+                        .frame(maxHeight: 128)
+                }
+            )
+            
+            SectionView(
+                title: "System Images",
+                description: "Built-in icons that represent common tasks and types of content in a variety of use cases. The full list of icons is available in the SF Symbols app.",
+                content: {
+                    Group {
+                        Image(systemName: "memories.badge.plus")
+                            // This modifier lets you use the new multi-color system icons in SF Symbols 2
+                            .renderingMode(.original)
+                        Image(systemName: "memories.badge.plus")
+                    }
                 }
             )
             

--- a/SwiftUI Kit/Groupings/ShapesGroup.swift
+++ b/SwiftUI Kit/Groupings/ShapesGroup.swift
@@ -8,6 +8,12 @@
 import SwiftUI
 
 struct ShapesGroup: View {
+    // Define constraints for the shape frames so they don’t stretch out too much on macOS
+    let frameMinWidth: CGFloat = 16
+    let frameMaxWidth: CGFloat = 256
+    let frameMinHeight: CGFloat = 32
+    let frameMaxHeight: CGFloat = 64
+    
     var body: some View {
         Group {
             SectionView(
@@ -15,6 +21,11 @@ struct ShapesGroup: View {
                 description: "A rectangular shape aligned inside the frame of the view containing it.",
                 content: {
                     Rectangle()
+                        .frame(
+                            minWidth: frameMinWidth,
+                            maxWidth: frameMaxWidth,
+                            minHeight: frameMinHeight,
+                            maxHeight: frameMaxHeight)
                 }
             )
             
@@ -23,6 +34,11 @@ struct ShapesGroup: View {
                 description: "A rectangular shape with rounded corners, aligned inside the frame of the view containing it.",
                 content: {
                     RoundedRectangle(cornerRadius: 4)
+                        .frame(
+                            minWidth: frameMinWidth,
+                            maxWidth: frameMaxWidth,
+                            minHeight: frameMinHeight,
+                            maxHeight: frameMaxHeight)
                 }
             )
             
@@ -31,6 +47,11 @@ struct ShapesGroup: View {
                 description: "A circle centered on the frame of the view containing it.",
                 content: {
                     Circle()
+                        .frame(
+                            minWidth: frameMinWidth,
+                            maxWidth: frameMaxWidth,
+                            minHeight: frameMinHeight,
+                            maxHeight: frameMaxHeight)
                 }
             )
             
@@ -39,6 +60,11 @@ struct ShapesGroup: View {
                 description: "An ellipse aligned inside the frame of the view containing it.",
                 content: {
                     Ellipse()
+                        .frame(
+                            minWidth: frameMinWidth,
+                            maxWidth: frameMaxWidth,
+                            minHeight: frameMinHeight,
+                            maxHeight: frameMaxHeight)
                 }
             )
             
@@ -47,6 +73,11 @@ struct ShapesGroup: View {
                 description: "A capsule shape aligned inside the frame of the view containing it.",
                 content: {
                     Capsule()
+                        .frame(
+                            minWidth: frameMinWidth,
+                            maxWidth: frameMaxWidth,
+                            minHeight: frameMinHeight,
+                            maxHeight: frameMaxHeight)
                 }
             )
         }

--- a/SwiftUI Kit/Groupings/TextGroup.swift
+++ b/SwiftUI Kit/Groupings/TextGroup.swift
@@ -38,6 +38,7 @@ struct TextGroup: View {
                 }
             )
             
+            #if os(iOS) || os(OSX)
             SectionView(
                 title: "TextEditor",
                 description: "A view that can display and edit long-form text.",
@@ -46,6 +47,7 @@ struct TextGroup: View {
                         .frame(height: 88)
                 }
             )
+            #endif
         }
     }
 }


### PR DESCRIPTION
- Add watchOS app!
- Exclude unsupported components with `#if os` statements
- Update Readme + add useful Apple links
- Add system images section in the Images group
- Refactor `var lineColor` to be a color set in the asset library instead (initially to avoid a big, ugly if else block but seems to be the better approach)
- Add `renderingMode(.original)` modifier example for multi-color system images
- Add frame constraints to the shapes examples so they don’t stretch out too much when resizing windows on macOS