### PR TITLE
Add proper spacing for the sheet on macOS

### DIFF
--- a/SwiftUI Kit/Groupings/ButtonsGroup.swift
+++ b/SwiftUI Kit/Groupings/ButtonsGroup.swift
@@ -32,11 +32,11 @@ struct ButtonsGroup: View {
                         }) {
                             Text("Show Sheet")
                         }.sheet(isPresented: $showingSheet) {
-                            Text("Sheet")
+                            Text("Sheet").padding()
                             #if os(macOS)
                             Button("Close") {
                                 showingSheet.toggle()
-                            }
+                            }.padding()
                             #endif
                         }
                         


### PR DESCRIPTION
This is one of the follow up items of #7, now looks like this:

<img width="934" alt="Screen Shot 2020-07-11 at 11 48 10" src="https://user-images.githubusercontent.com/4551135/87231516-b5ab2d00-c36c-11ea-8be3-9bd6dea9df5a.png">
