### PR TITLE
Alert Dialog: Add Secondary Button Style

### DIFF
--- a/SwiftUI Kit/Groupings/ButtonsGroup.swift
+++ b/SwiftUI Kit/Groupings/ButtonsGroup.swift
@@ -24,7 +24,12 @@ struct ButtonsGroup: View {
                             Text("Show Alert")
                         }
                         .alert(isPresented: $showingAlert) {
-                            Alert(title: Text("Title"), message: Text("Message"), dismissButton: .default(Text("OK")))
+                            Alert(
+                                title: Text("Title"),
+                                message: Text("Message"),
+                                primaryButton: .default(Text("Confirm")),
+                                secondaryButton: .cancel()
+                            )
                         }
                         
                         Button(action: {


### PR DESCRIPTION
Add a secondary button to the alert dialog to show the other available button style.

### iOS
<img width="380" alt="Screen Shot 2020-07-11 at 15 02 42" src="https://user-images.githubusercontent.com/23482161/87231732-9d94d700-c387-11ea-8e9d-771664f7d052.png">

### macOS
<img width="372" alt="Screen Shot 2020-07-11 at 14 58 25" src="https://user-images.githubusercontent.com/23482161/87231726-953c9c00-c387-11ea-99cc-bc2a4975ca34.png">
