### PR TITLE
Toggle: differentiate checkbox and switch styles

### DIFF
--- a/SwiftUI Kit/Groupings/ControlsGroup.swift
+++ b/SwiftUI Kit/Groupings/ControlsGroup.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct ControlsGroup: View {
     @State private var vibrateOnRing = true
+    @State private var vibrateOnSilent = true
     @State private var selectedFlavor = Flavor.chocolate
     @State private var birthday = Date()
     @State private var volume = 50.0
@@ -17,8 +18,13 @@ struct ControlsGroup: View {
 
     var body: some View {
         Group {
-            SectionView(title: "Toggle", description: "A control that toggles between on and off states.") {
-                Toggle("Vibrate on Ring", isOn: $vibrateOnRing)
+            SectionView(title: "Toggle", description: "A control that toggles between on and off states. The default style is a switch on iOS, and a checkbox on macOS.") {
+                Group {
+                    Toggle("Vibrate on Ring", isOn: $vibrateOnRing)
+                    
+                    Toggle("Vibrate on Silent", isOn: $vibrateOnSilent)
+                        .toggleStyle(SwitchToggleStyle())
+                }
             }
             
             SectionView(title: "Picker", description: "A control for selecting from a set of mutually exclusive values.") {


### PR DESCRIPTION
Checkbox style only applies on macOS

<img width="470" alt="Screen Shot 2020-07-11 at 12 09 13 PM" src="https://user-images.githubusercontent.com/133910/87231979-45060f80-c370-11ea-9817-968d70d6fe92.png">

![Simulator Screen Shot - iPad Pro (12 9-inch) (4th generation) - 2020-07-11 at 12 08 48](https://user-images.githubusercontent.com/133910/87231981-48999680-c370-11ea-9a2f-e262ddf8774a.png)
