### PR TITLE
macOS Content View Padding Enhancement

### DIFF
--- a/SwiftUI Kit/GroupView.swift
+++ b/SwiftUI Kit/GroupView.swift
@@ -20,8 +20,8 @@ struct GroupView<Content: View>: View {
         .navigationBarTitle(title, displayMode: .inline)
         #else
         return ScrollView {
-            content()
-        }.frame(maxWidth: .infinity, maxHeight: .infinity).padding()
+            content().padding()
+        }.frame(maxWidth: .infinity, maxHeight: .infinity)
         #endif
     }
 }


### PR DESCRIPTION
Moving padding on the mac to the content in the scroll view, which will let the scroll bar be up against the edge of the window, rather than be inset.

![Screen Shot 2020-07-11 at 3 59 23 PM](https://user-images.githubusercontent.com/5921571/87235301-8528ba80-c38f-11ea-9398-a673860d5f88.png)
