### PR TITLE
fix: SignInWithAppleButton error

### DIFF
--- a/Shared/Groupings/ButtonsGroup.swift
+++ b/Shared/Groupings/ButtonsGroup.swift
@@ -5,6 +5,7 @@
 //  Created by Jordan Singer on 7/10/20.
 //
 import SwiftUI
+import AuthenticationServices
 
 struct ButtonsGroup: View {
     @State private var showingAlert = false


### PR DESCRIPTION
`SignInWithAppleButton` has moved from `SwiftUI` to `AuthenticationServices` since Xcode 12.0 beta 6