### PR TITLE
Update macOS deployment target to 11.0

### DIFF
--- a/SwiftUI Kit.xcodeproj/project.pbxproj
+++ b/SwiftUI Kit.xcodeproj/project.pbxproj
@@ -1026,7 +1026,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.16;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "lilsoftware-Kit-Mac";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;
@@ -1050,7 +1050,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.16;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "lilsoftware.SwiftUI-Kit-Mac";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = macosx;


### PR DESCRIPTION
Update the default deployment target for macOS to 11.0 now that the Big Sur general release is available.