### PR TITLE
Updated fonts.swift to properly represent sizing

### DIFF
--- a/Shared/Groupings/FontsGroup.swift
+++ b/Shared/Groupings/FontsGroup.swift
@@ -55,20 +55,18 @@ struct FontsGroup: View {
             }
             
             Group {
+                SectionView(description: "A font with the footnote text style.") {
+                    Text("footnote")
+                        .font(.footnote)
+                }
                 SectionView(description: "A font with the caption text style.") {
                     Text("caption")
                         .font(.caption)
                 }
-                
                 SectionView(description: "Create a font with the alternate caption text style.") {
                     Text("caption2")
                         .font(.caption2)
                 }
-            }
-            
-            SectionView(description: "A font with the footnote text style.") {
-                Text("footnote")
-                    .font(.footnote)
             }
         }
     }


### PR DESCRIPTION
Moved `.font(.footnote)`  above the caption font sizes.

The default `.font(.footnote)` is a size of 13.0, while  `.font(.caption)` and  `.font(.caption2)` are 12.0 and 11.0 respectively

